### PR TITLE
fix setuptools auto-discovery process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import setup
@@ -12,5 +12,6 @@ setup(
     author_email='dev@wazo.community',
     url='http://wazo-platform.org',
     license='GPLv3',
+    packages=[],
     scripts=['bin/wazo-confgen'],
 )


### PR DESCRIPTION
why: since setuptools v61.1.0, setuptools trigger an error if packages
is not there to avoid to include unwanted files. Since this client
can be installed everywhere (not only on buster). Adding packages fix
the thing and is future proof